### PR TITLE
Cache clear command is executed from current dir

### DIFF
--- a/src/RoboFileBase.php
+++ b/src/RoboFileBase.php
@@ -87,9 +87,8 @@ class RoboFileBase extends AbstractRoboFile
      */
     protected function clearCacheTask($worker, $auth, $remote)
     {
-        $currentProjectRoot = $remote['rootdir'];
         return $this->taskSsh($worker, $auth)
-            ->remoteDirectory($currentProjectRoot, true)
+            ->remoteDirectory($remote['currentdir'], true)
             ->timeout(120)
             ->exec($this->console . ' cache:clear')
             ->exec($this->console . ' cache:warmup');

--- a/src/RoboFileBase.php
+++ b/src/RoboFileBase.php
@@ -88,7 +88,7 @@ class RoboFileBase extends AbstractRoboFile
     protected function clearCacheTask($worker, $auth, $remote)
     {
         return $this->taskSsh($worker, $auth)
-            ->remoteDirectory($remote['currentdir'], true)
+            ->remoteDirectory($remote['currentdir'] . '/..', true)
             ->timeout(120)
             ->exec($this->console . ' cache:clear')
             ->exec($this->console . ' cache:warmup');


### PR DESCRIPTION
Clearing the cache was previously done from the root directory (see
`remote.rootdir` in `default.properties.yml`).  This worked ok for new
releases, but not for sync jobs where there is no new rootdir, since
nothing is deployed.
Therefor, we use the current directory (see `remote.currentdir` in
`default.properties.yml`) to execute the cache:clear command from.

Closes #11